### PR TITLE
Exchange type spec hrl is going away

### DIFF
--- a/src/rabbit_exchange_type_random.erl
+++ b/src/rabbit_exchange_type_random.erl
@@ -17,7 +17,6 @@
 -module(rabbit_exchange_type_random).
 -behaviour(rabbit_exchange_type).
 -include_lib("rabbit_common/include/rabbit.hrl").
--include_lib("rabbit_common/include/rabbit_exchange_type_spec.hrl").
 
 -rabbit_boot_step({?MODULE, [
   {description,   "exchange type random"},


### PR DESCRIPTION
Now that dialyzer can understand typed behaviour callbacks it doesn't make sense for us to have separate hrl files for them any more. So after the next RabbitMQ release this include directive will need to go away.
