### PR TITLE
Update to add rabbit_exchange_type:policy_changed/3

### DIFF
--- a/src/rabbit_exchange_type_random.erl
+++ b/src/rabbit_exchange_type_random.erl
@@ -30,6 +30,7 @@
   assert_args_equivalence/2,
   create/2, 
   delete/3, 
+  policy_changed/3,
   description/0, 
   recover/2, 
   remove_bindings/3,
@@ -59,6 +60,7 @@ validate(_X) -> ok.
 create(_Tx, _X) -> ok.
 recover(_X, _Bs) -> ok.
 delete(_Tx, _X, _Bs) -> ok.
+policy_changed(_Tx, _X1, _X2) -> ok.
 add_binding(_Tx, _X, _B) -> ok.
 remove_bindings(_Tx, _X, _Bs) -> ok.
 assert_args_equivalence(X, Args) ->


### PR DESCRIPTION
Hi. 2.9.0 will add another function to the exchange type API. In most cases this can be a no-op, so this is pretty trivial. When compiling against 2.8.x it's just an exported-but-unused function, so this can be applied immediately.
